### PR TITLE
add missing dependency

### DIFF
--- a/open_manipulator_controllers/package.xml
+++ b/open_manipulator_controllers/package.xml
@@ -18,6 +18,8 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>urdf</depend>
+  <depend>joint_trajectory_controller</depend>
+  <depend>moveit_simple_controller_manager</depend>
 
   <export>
     <controller_interface plugin="${prefix}/controller_plugin.xml" />


### PR DESCRIPTION
In my case, these pkgs are necessary to run
```
$ roslaunch open_manipulator_controllers joint_trajectory_controller.launch sim:=false
```