### PR TITLE
added gazebo controller params

### DIFF
--- a/open_manipulator_hw/launch/open_manipulator_gazebo.launch
+++ b/open_manipulator_hw/launch/open_manipulator_gazebo.launch
@@ -4,6 +4,8 @@
   <arg name="paused" default="true"/>
   <arg name="use_sim_time" default="true"/>
 
+  <rosparam file="$(find open_manipulator_gazebo)/config/gazebo_controller.yaml" command="load"/>
+
   <!-- startup simulated world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="paused" value="$(arg paused)"/>


### PR DESCRIPTION
For the gripper to work, a gazebo controller with PIDs specified needs to be set. See https://github.com/ROBOTIS-GIT/open_manipulator/pull/231 and https://github.com/ROBOTIS-GIT/open_manipulator_simulations/pull/18